### PR TITLE
Add dotenv-based configuration support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/vendor/
+/conf/.env

--- a/README.md
+++ b/README.md
@@ -33,6 +33,24 @@ building a new application with good defaults.
    composer fix    # PHP-CS-Fixer
    ```
 
+## Configuration
+
+Configuration values can be supplied via environment variables or a `.env` file.
+For local development, copy [`conf/.env.example`](conf/.env.example) to `conf/.env`
+and adjust values as needed. The `docker-compose.yml` mounts the `conf/`
+directory into the container at `/conf`, and the application will load variables
+from `/conf/.env` if present. Environment variables already defined will take
+precedence over values from the file.
+
+Load the configuration at the beginning of your application:
+
+```php
+use App\Config;
+
+Config::load();
+$appName = Config::get('APP_NAME', 'My App');
+```
+
 ## Configuration for your project
 
 - **Composer package name**: update the `name` field in [`composer.json`](./composer.json) from `andrehebben/your-app` to your own package identifier.

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,8 @@
   "name": "andrehebben/your-app",
   "require": {
     "php": "^8.2",
-    "ext-json": "*"
+    "ext-json": "*",
+    "vlucas/phpdotenv": "^5.6"
   },
   "require-dev": {
     "phpunit/phpunit": "^11.0",

--- a/conf/.env.example
+++ b/conf/.env.example
@@ -1,0 +1,3 @@
+# Example configuration file
+# Copy to .env and adjust values for your environment
+APP_NAME=PHP Docker Skeleton

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     image: ghcr.io/andrehebben/your-app:dev
     volumes:
       - .:/app
+      - ./conf:/conf:ro
     command: php -S 0.0.0.0:8080 -t public
     ports:
       - "8080:8080"

--- a/src/Config.php
+++ b/src/Config.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App;
+
+use Dotenv\Dotenv;
+
+final class Config
+{
+    public static function load(string $directory = '/conf'): void
+    {
+        $envFile = rtrim($directory, '/').'/'.'.env';
+        if (is_readable($envFile)) {
+            Dotenv::createImmutable($directory)->safeLoad();
+        }
+    }
+
+    public static function get(string $key, ?string $default = null): ?string
+    {
+        return $_ENV[$key] ?? $_SERVER[$key] ?? $default;
+    }
+}

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests;
+
+use App\Config;
+use PHPUnit\Framework\TestCase;
+
+final class ConfigTest extends TestCase
+{
+    public function testLoadReadsEnvFile(): void
+    {
+        $tempDir = sys_get_temp_dir() . '/dotenv-test-' . uniqid();
+        mkdir($tempDir);
+        file_put_contents($tempDir . '/.env', "FOO=bar\n");
+
+        Config::load($tempDir);
+
+        $this->assertSame('bar', Config::get('FOO'));
+
+        unlink($tempDir . '/.env');
+        rmdir($tempDir);
+    }
+
+    public function testGetReturnsDefaultWhenMissing(): void
+    {
+        $this->assertSame('default', Config::get('MISSING', 'default'));
+    }
+}


### PR DESCRIPTION
## Summary
- add configuration loader using `vlucas/phpdotenv`
- mount a `/conf` directory with sample `.env` file
- document environment configuration usage

## Testing
- `composer lint` *(fails: phpcs not found)*
- `composer stan` *(fails: phpstan not found)*
- `composer test` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c379295883329b2309ef957b5ef8