### PR TITLE
Add index page and configure coverage

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,4 +5,12 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory>src</directory>
+        </include>
+        <report>
+            <text outputFile="php://stdout" />
+        </report>
+    </coverage>
 </phpunit>

--- a/public/index.php
+++ b/public/index.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Config;
+use App\Greeter;
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+Config::load(dirname(__DIR__) . '/conf');
+
+$greeter = new Greeter();
+$name = Config::get('NAME', 'World');
+
+echo $greeter->greet($name);

--- a/tests/IndexTest.php
+++ b/tests/IndexTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+final class IndexTest extends TestCase
+{
+    public function testIndexOutputsGreeting(): void
+    {
+        $_ENV['NAME'] = 'World';
+        ob_start();
+        require __DIR__ . '/../public/index.php';
+        $output = trim(ob_get_clean() ?: '');
+        $this->assertSame('Hello, World', $output);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `public/index.php` front controller to output greeting using env variable
- Configure PHPUnit to generate coverage reports
- Test index output via new unit test

## Testing
- `composer test` *(fails: phpunit: not found)*
- `composer lint` *(fails: phpcs: not found)*
- `composer stan` *(fails: phpstan: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c7ddb2688332a1f983c7715ddd23